### PR TITLE
Remove python 3 requirement.

### DIFF
--- a/requests_kerberos/__init__.py
+++ b/requests_kerberos/__init__.py
@@ -21,4 +21,4 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = ('HTTPKerberosAuth', 'MutualAuthenticationError', 'REQUIRED',
            'OPTIONAL', 'DISABLED')
-__version__ = '0.14.0'
+__version__ = '0.14.1'

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         'pyspnego[kerberos]',
     ],
     extras_require={},
-    python_requires='>=3.6',
     classifiers=[
         "License :: OSI Approved :: ISC License (ISCL)"
     ],


### PR DESCRIPTION
Background
Pykerberos cannot be installed on OSX Monterey.  Requests-kerberos removed the dependency on pykerberos and replaced it with pyspnego, but added a Python 3 requirement.  
[Shortcut Story](https://app.shortcut.com/nylas/story/72693/pykerberos-installation-fails-on-osx-12 )

Implementation
Remove requirement for Python 3.6

Tests
All CC test continue to pass after updating the requirement